### PR TITLE
fixed resolve, reject bug; resulting in conveying incorrect information

### DIFF
--- a/content/JavaScript/promise.jsdoc
+++ b/content/JavaScript/promise.jsdoc
@@ -83,7 +83,7 @@ Also schedules **onFinally** to be called when the promise has been either resol
 or rejected.
 
 <example>
-var promise = new Promise((reject, resolve) => {
+var promise = new Promise((resolve, reject) => {
   let x = Math.random();
   if (x < 0.5) {
     resolve(x);

--- a/docs/Promise.html
+++ b/docs/Promise.html
@@ -43,7 +43,7 @@ rejectPromise.catch(function(result) {
   console.log(&#39;caught: &#39; + result);
 });
 </textarea><a onclick='executeExample(this.parentNode.parentNode, "Promise.catch"); return false' href="#" class="run">Run</a></div><div class="resultsPanel"><h4>Results:</h4><div style="position: relative"><div class="errormessage" style="display: none"></div><pre class="results"> </pre></div></div></div><p></p><div class="membermetadata"><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-promise.prototype.catch" class="spec">Spec</a></div></div></div><div class="member"><div class="expand-members" title="Toggle showing all descriptions and examples"></div><a name="finally"></a> <a name="finally_Function"></a><div class="declaration"><span class="membername primary">finally</span>(<span class="membername">onFinally</span>&nbsp;:&nbsp;<a class="membertype" href="/Function">Function</a>)&nbsp;:&nbsp;<a class="membertype" href="/Promise">Promise</a><div class="subfunction"><span class="membername">onFinally</span>()&nbsp;:&nbsp;<a class="membertype" href="/undefined">undefined</a></div></div><div class="member-body"><p class="description">Also schedules <code>onFinally</code> to be called when the promise has been either resolved or rejected.</p><div class="example"><div class="codePanel"><h4>Example:</h4><textarea class="code" rows="12" cols="60" wrap="off">
-var promise = new Promise((reject, resolve) =&gt; {
+var promise = new Promise((resolve, reject) =&gt; {
   let x = Math.random();
   if (x &lt; 0.5) {
     resolve(x);


### PR DESCRIPTION
This PR fixes a bug which was incorrectly resolving/rejecting a promise. The order of arguments that promise class returns is in this form: `resolve, reject`. In the original code when the condition is satisfied it resolves the promise, however, it rejects the promise because resolve is given the value of reject and vice versa in the callback function. This PR fixes that issue and promises are resolved or rejected properly, showing a proper log to the console. 

Screengrab from the deployed site (current master code):

<img width="914" alt="image" src="https://github.com/nkronlage/JavaScripture/assets/71615163/f2a985ea-5d8b-4156-96ae-3f214425fec3">

In the above picture, the value of variable x is 0.39 which is < 0.5. The promise is resolved as per the call however on the right we can see that the promise was in fact rejected.

@nkronlage @shpetimaliu Please let me know if there are any changes to be made as part of this PR. Thanks!

Also, will it be possible to tag this PR with `Hacktoberfest` and `hacktoberfest-accepted` labels once it gets approved & merged? Would be very helpful.